### PR TITLE
bug fix for sshd server can not start up for ubuntu 18.04

### DIFF
--- a/dockerfiles/ubuntu-18.04/Dockerfile
+++ b/dockerfiles/ubuntu-18.04/Dockerfile
@@ -3,5 +3,6 @@ COPY ./scripts/ansible_install.sh /tmp
 RUN export APT_INSTALL="apt-get --no-install-recommends -y install" && \
     bash /tmp/ansible_install.sh && \
     ${APT_INSTALL} sudo openssh-server curl lsb-release && \
+    mkdir -p /run/sshd && \
     apt-get clean all && \
     rm -rf /tmp/* /var/tmp/*


### PR DESCRIPTION
bug fix for sshd server can not start up for ubuntu 18.04 with test-kitchen-docker.